### PR TITLE
html2text: update to 2.3.0

### DIFF
--- a/html2text.spec
+++ b/html2text.spec
@@ -1,13 +1,11 @@
 Summary:	A command line utility to convert HTML document to plain text
 Name:		html2text
-Version:	1.3.2a
-Release:	26
+Version:	2.3.0
+Release:	27
 Group:		File tools
 License:	GPLv2
-Url:    https://github.com/grobian/html2text
-# Previous (old) url:
-#Url:		http://www.mbayer.de/html2text/
-Source0:        http://www.mbayer.de/html2text/downloads/%{name}-%{version}.tar.bz2
+Url:		https://github.com/grobian/html2text
+Source0:	https://github.com/grobian/html2text/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
 %description
 html2text is a command line utility, written in C++, that converts HTML
@@ -23,13 +21,11 @@ documents into plain text.
 %install
 mkdir -p %{buildroot}/{%{_bindir},%{_mandir}/{man1,man5}}
 
-gunzip %{name}.1.gz %{name}rc.5.gz
-
 install -m755 %{name} %{buildroot}%{_bindir}
 install -m644 %{name}.1  %{buildroot}%{_mandir}/man1/
 install -m644 %{name}rc.5 %{buildroot}%{_mandir}/man5/
 
 %files
-%doc CHANGES COPYING CREDITS INSTALL KNOWN_BUGS RELEASE_NOTES README TODO
+%doc ChangeLog.md COPYING CREDITS INSTALL KNOWN_BUGS README.md
 %{_bindir}/*
 %{_mandir}/man?/*


### PR DESCRIPTION
Bump Version to 2.3.0
Update Source0 to point to the new upstream tarball
Remove outdated/obsolete gunzip commands for manpages
Minor formatting / cleanup in spec for readability

Some issues reported in (OM#[3342](https://github.com/OpenMandrivaAssociation/distribution/issues/3342)) appear related to the old version